### PR TITLE
Added display of business description and image on business detail view

### DIFF
--- a/app/src/main/java/com/example/golocal/fragments/BusinessDetailFragment.java
+++ b/app/src/main/java/com/example/golocal/fragments/BusinessDetailFragment.java
@@ -106,8 +106,12 @@ public class BusinessDetailFragment extends Fragment {
 
     private void setFields(String data) throws JSONException {
         JSONObject queryResponse = new JSONObject(data);
-        String businessDescription = queryResponse.getString("description");
-        tvBusinessDescription.setText(businessDescription);
+        String businessDescription = queryResponse.optString("description");
+        if (businessDescription != null) {
+            tvBusinessDescription.setText(businessDescription);
+        } else {
+            tvBusinessDescription.setVisibility(View.GONE);
+        }
         JSONArray photos = queryResponse.getJSONArray("photos");
         if (photos.getJSONObject(0) != null) {
             JSONObject businessPhoto = photos.getJSONObject(0);
@@ -116,7 +120,6 @@ public class BusinessDetailFragment extends Fragment {
             String dimensions = Integer.valueOf(screenWidth) + "x" + Integer.valueOf(screenWidth);
             String imageUrl = prefix + dimensions + suffix;
             Glide.with(this).load(imageUrl).override(screenWidth, screenWidth).into(ivBusinessImage);
-            Log.i("DetailFragment", imageUrl);
         } else {
             ivBusinessImage.setVisibility(View.GONE);
         }

--- a/app/src/main/java/com/example/golocal/fragments/BusinessDetailFragment.java
+++ b/app/src/main/java/com/example/golocal/fragments/BusinessDetailFragment.java
@@ -1,23 +1,44 @@
 package com.example.golocal.fragments;
 
+import android.app.Activity;
+import android.os.AsyncTask;
 import android.os.Bundle;
+import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
+import com.bumptech.glide.Glide;
 import com.example.golocal.R;
 import com.example.golocal.models.BusinessDataModel;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 
 public class BusinessDetailFragment extends Fragment {
 
     private TextView tvBusinessTitle;
     private TextView tvBusinessAddress;
+    private TextView tvBusinessDescription;
+    private ImageView ivBusinessImage;
     private BusinessDataModel businessDataModel;
+    private final String PLACES_URL = "https://api.foursquare.com/v3/places/";
+    private OkHttpClient client = new OkHttpClient();
+    private int screenWidth;
 
     public BusinessDetailFragment(BusinessDataModel clickedBusiness) {
         this.businessDataModel = clickedBusiness;
@@ -33,9 +54,71 @@ public class BusinessDetailFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        ((Activity) getContext()).getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
+        screenWidth = displayMetrics.widthPixels;
+
+        String foursquareId = businessDataModel.getFoursquareId();
+        PlaceQueryCall call = new PlaceQueryCall();
+        call.execute(foursquareId);
+
         tvBusinessTitle = view.findViewById(R.id.tvBusinessTitle);
         tvBusinessAddress = view.findViewById(R.id.tvBusinessAddress);
+        tvBusinessDescription = view.findViewById(R.id.tvBusinessDescription);
+        ivBusinessImage = view.findViewById(R.id.ivBusinessImage);
         tvBusinessTitle.setText(businessDataModel.getName());
         tvBusinessAddress.setText(businessDataModel.getAddress());
+
+    }
+
+    private class PlaceQueryCall extends AsyncTask<String, Void, String> {
+
+        @Override
+        protected String doInBackground(String... params) {
+            Request request = new Request.Builder()
+                    .url(PLACES_URL + params[0] + "?fields=description,photos")
+                    .get()
+                    .addHeader("Accept", "application/json")
+                    .addHeader("Authorization", getResources().getString(R.string.foursquare_api_key))
+                    .build();
+
+
+            Response response;
+            String results;
+            try {
+                response = client.newCall(request).execute();
+                results = response.body().string();
+            } catch (IOException e) {
+                e.printStackTrace();
+                return null;
+            }
+            return results;
+        }
+
+        protected void onPostExecute(String results) {
+            try {
+                setFields(results);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void setFields(String data) throws JSONException {
+        JSONObject queryResponse = new JSONObject(data);
+        String businessDescription = queryResponse.getString("description");
+        tvBusinessDescription.setText(businessDescription);
+        JSONArray photos = queryResponse.getJSONArray("photos");
+        if (photos.getJSONObject(0) != null) {
+            JSONObject businessPhoto = photos.getJSONObject(0);
+            String prefix = businessPhoto.getString("prefix");
+            String suffix = businessPhoto.getString("suffix");
+            String dimensions = Integer.valueOf(screenWidth) + "x" + Integer.valueOf(screenWidth);
+            String imageUrl = prefix + dimensions + suffix;
+            Glide.with(this).load(imageUrl).override(screenWidth, screenWidth).into(ivBusinessImage);
+            Log.i("DetailFragment", imageUrl);
+        } else {
+            ivBusinessImage.setVisibility(View.GONE);
+        }
     }
 }

--- a/app/src/main/java/com/example/golocal/fragments/MapFragment.java
+++ b/app/src/main/java/com/example/golocal/fragments/MapFragment.java
@@ -235,6 +235,7 @@ public class MapFragment extends Fragment {
         for (int i = 0; i < results.length(); i++) {
             JSONObject business = results.getJSONObject(i);
             String address = business.getJSONObject("location").getString("address");
+            String foursquareId = business.getString("fsq_id");
             String latitude = business.getJSONObject("geocodes").getJSONObject("main").getString("latitude");
             String longitude = business.getJSONObject("geocodes").getJSONObject("main").getString("longitude");
             LatLng markerPosition = new LatLng(Double.parseDouble(latitude), Double.parseDouble(longitude));
@@ -245,6 +246,7 @@ public class MapFragment extends Fragment {
             BusinessDataModel currentBusiness = new BusinessDataModel();
             currentBusiness.setName(businessName);
             currentBusiness.setAddress(address);
+            currentBusiness.setFoursquareId(foursquareId);
             Marker mapMarker = map.addMarker(new MarkerOptions()
                     .position(markerPosition)
                     .title(businessName)

--- a/app/src/main/java/com/example/golocal/models/BusinessDataModel.java
+++ b/app/src/main/java/com/example/golocal/models/BusinessDataModel.java
@@ -13,6 +13,7 @@ public class BusinessDataModel extends ParseObject {
     public static final String KEY_IMAGE = "image";
     public static final String KEY_ADDRESS = "address";
     public static final String KEY_DESCRIPTION = "description";
+    public static final String KEY_FOURSQUAREID = "foursquareID";
     private final String TAG = "BusinessDataModel";
 
     public String getName() {
@@ -50,5 +51,13 @@ public class BusinessDataModel extends ParseObject {
 
     public void setDescription(String description) {
         put(KEY_DESCRIPTION, description);
+    }
+
+    public String getFoursquareId() {
+        return getString(KEY_FOURSQUAREID);
+    }
+
+    public void setFoursquareId(String id) {
+        put(KEY_FOURSQUAREID, id);
     }
 }

--- a/app/src/main/res/layout/fragment_business_detail.xml
+++ b/app/src/main/res/layout/fragment_business_detail.xml
@@ -25,4 +25,27 @@
         android:text="TextView"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tvBusinessTitle" />
+
+    <TextView
+        android:id="@+id/tvBusinessDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="4dp"
+        android:text="TextView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/ivBusinessImage" />
+
+    <ImageView
+        android:id="@+id/ivBusinessImage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvBusinessAddress"
+        tools:srcCompat="@tools:sample/avatars" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
On the business detail view that appears when a marker from the map is clicked, I have added the display of a description of the business and an image (if these fields are available from the Foursquare API). To do this, I store the Foursquare ID of the business in the businessDataModel object. Then, when the app navigates to the business detail view, I make a request for the details of that business from the Foursquare API using the Foursquare ID I have stored in the object. This optionally returns a description and image if they're available, and I load these into a TextView and ImageView on the screen. Below is an example of what this looks like.

https://user-images.githubusercontent.com/26172675/176308957-321dee30-c622-491d-86b2-1be6fc48f3ad.mov


