### PR TITLE
Users can add friends

### DIFF
--- a/app/src/main/java/com/example/golocal/adapters/GuidesAdapter.java
+++ b/app/src/main/java/com/example/golocal/adapters/GuidesAdapter.java
@@ -77,7 +77,7 @@ public class GuidesAdapter extends RecyclerView.Adapter<GuidesAdapter.ViewHolder
             int position = getAdapterPosition();
             if (position != RecyclerView.NO_POSITION) {
                 GuideDataModel guideDataModel = guideDataModels.get(position);
-                Fragment fragment = new GuideDetailFragment(guideDataModel);
+                Fragment fragment = new GuideDetailFragment(guideDataModel, mainActivity);
                 FragmentTransaction fragmentTransaction = mainActivity.fragmentManager.beginTransaction().replace(R.id.flContainer, fragment);
                 fragmentTransaction.addToBackStack(null);
                 fragmentTransaction.commit();

--- a/app/src/main/java/com/example/golocal/fragments/GuideDetailFragment.java
+++ b/app/src/main/java/com/example/golocal/fragments/GuideDetailFragment.java
@@ -9,10 +9,12 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.golocal.R;
+import com.example.golocal.activities.MainActivity;
 import com.example.golocal.adapters.BusinessAdapter;
 import com.example.golocal.models.GuideDataModel;
 
@@ -24,9 +26,11 @@ public class GuideDetailFragment extends Fragment {
     private TextView tvDescriptionDetail;
     private RecyclerView rvBusinessesDetail;
     private BusinessAdapter adapter;
+    private MainActivity mainActivity;
 
-    public GuideDetailFragment(GuideDataModel guideDataModel) {
+    public GuideDetailFragment(GuideDataModel guideDataModel, MainActivity main) {
         this.guideDataModel = guideDataModel;
+        this.mainActivity = main;
     }
 
     @Nullable
@@ -50,5 +54,15 @@ public class GuideDetailFragment extends Fragment {
         tvDescriptionDetail.setText(guideDataModel.getDescription());
         rvBusinessesDetail.setAdapter(adapter);
         rvBusinessesDetail.setLayoutManager(new LinearLayoutManager(getContext()));
+
+        tvAuthorDetail.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ProfileFragment profileFragment = new ProfileFragment(guideDataModel.getAuthor());
+                FragmentTransaction fragmentTransaction = mainActivity.fragmentManager.beginTransaction().replace(R.id.flContainer, profileFragment);
+                fragmentTransaction.addToBackStack(null);
+                fragmentTransaction.commit();
+            }
+        });
     }
 }

--- a/app/src/main/java/com/example/golocal/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/example/golocal/fragments/ProfileFragment.java
@@ -55,7 +55,8 @@ public class ProfileFragment extends Fragment {
     private final String photoFileName = "photo.jpg";
 
     private final String KEY_BIO = "bio";
-    private final String KEY_IMAGE = "profileImage";
+    private static final String KEY_IMAGE = "profileImage";
+    private static final String KEY_FRIENDS = "friends";
     private final String TAG = "ProfileFragment";
 
     private TextView tvUsername;
@@ -126,7 +127,7 @@ public class ProfileFragment extends Fragment {
         ibAddFriend = view.findViewById(R.id.ibAddFriend);
         ibRemoveFriend = view.findViewById(R.id.ibRemoveFriend);
 
-        List<ParseUser> friends = ParseUser.getCurrentUser().getList("friends");
+        List<ParseUser> friends = ParseUser.getCurrentUser().getList(KEY_FRIENDS);
         if (friends != null) {
             for (int i = 0; i < friends.size(); i++) {
                 String id = friends.get(i).getObjectId();
@@ -141,9 +142,6 @@ public class ProfileFragment extends Fragment {
             setAddFriendListener();
             setRemoveFriendListener();
             if (!friendIds.contains(user.getObjectId())) {
-                for (int i = 0; i < friends.size(); i++) {
-                    Log.e("friend", friends.get(i).getObjectId());
-                }
                 ibAddFriend.setVisibility(View.VISIBLE);
             } else {
                 ibRemoveFriend.setVisibility(View.VISIBLE);
@@ -208,19 +206,18 @@ public class ProfileFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 ParseUser currentUser = ParseUser.getCurrentUser();
-                List<ParseUser> friends = currentUser.getList("friends");
+                List<ParseUser> friends = currentUser.getList(KEY_FRIENDS);
                 if (friends == null) {
                     friends = new ArrayList<>();
                 }
                 friends.add(user);
                 friendIds.add(user.getObjectId());
-                currentUser.put("friends", friends);
-                Log.e("friends", friends.toString());
+                currentUser.put(KEY_FRIENDS, friends);
                 currentUser.saveInBackground(new SaveCallback() {
                     @Override
                     public void done(ParseException e) {
                         if (e != null) {
-                            Log.e("ProfileFragment", "error while saving friends", e);
+                            Log.e(TAG, "error while saving friends", e);
                         }
                     }
                 });
@@ -236,7 +233,7 @@ public class ProfileFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 ParseUser currentUser = ParseUser.getCurrentUser();
-                List<ParseUser> friends = currentUser.getList("friends");
+                List<ParseUser> friends = currentUser.getList(KEY_FRIENDS);
                 if (friends == null) {
                     friends = new ArrayList<>();
                 }
@@ -246,13 +243,12 @@ public class ProfileFragment extends Fragment {
                     }
                 }
                 friendIds.remove(user.getObjectId());
-                currentUser.put("friends", friends);
-                Log.e("friends", friends.toString());
+                currentUser.put(KEY_FRIENDS, friends);
                 currentUser.saveInBackground(new SaveCallback() {
                     @Override
                     public void done(ParseException e) {
                         if (e != null) {
-                            Log.e("ProfileFragment", "error while saving friends", e);
+                            Log.e(TAG, "error while saving friends", e);
                         }
                     }
                 });

--- a/app/src/main/java/com/example/golocal/models/UserDataModel.java
+++ b/app/src/main/java/com/example/golocal/models/UserDataModel.java
@@ -1,0 +1,13 @@
+package com.example.golocal.models;
+
+import com.parse.ParseUser;
+
+import java.util.List;
+
+public class UserDataModel extends ParseUser {
+    public static final String KEY_FRIENDS = "friends";
+
+    public List<ParseUser> getFriends() {
+        return getList(KEY_FRIENDS);
+    }
+}

--- a/app/src/main/res/layout/fragment_guide_detail.xml
+++ b/app/src/main/res/layout/fragment_guide_detail.xml
@@ -21,6 +21,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
+        android:clickable="true"
         android:text="TextView"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tvTitleDetail" />

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -93,4 +93,24 @@
         android:text="Choose from gallery"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tvBio" />
+
+    <ImageButton
+        android:id="@+id/ibAddFriend"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
+        android:layout_marginStart="16dp"
+        android:visibility="gone"
+        app:layout_constraintStart_toEndOf="@id/ivProfileImage"
+        app:layout_constraintTop_toBottomOf="@id/tvUsername"
+        app:srcCompat="@android:drawable/ic_menu_add" />
+
+    <ImageButton
+        android:id="@+id/ibRemoveFriend"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
+        android:layout_marginStart="16dp"
+        android:visibility="gone"
+        app:layout_constraintStart_toEndOf="@id/ivProfileImage"
+        app:layout_constraintTop_toBottomOf="@id/tvUsername"
+        app:srcCompat="@android:drawable/ic_menu_close_clear_cancel" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
I added friends functionality to the app. Specifically, users can view other user's profiles by clicking on the user from the guides detail fragments. Whenever a profile fragment is created that isn't for the profile of the current user of the app, a button will appear to add or remove the friend (depending on whether the user is currently a friend). Right now, this only works when navigating to the profile of the user from the guides fragment, since I haven't yet added a search bar to find other users. In the future, though, I plan to add more paths for users to be able to navigate to other user's profiles. I've included a video below of this functionality.

https://user-images.githubusercontent.com/26172675/178842317-b56547bd-5f9b-4162-a479-4c25ba5b36e4.mov

