### PR TITLE
Added crossfade animation to bio editing

### DIFF
--- a/app/src/main/java/com/example/golocal/adapters/GuidesAdapter.java
+++ b/app/src/main/java/com/example/golocal/adapters/GuidesAdapter.java
@@ -1,13 +1,9 @@
 package com.example.golocal.adapters;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.transition.Scene;
 import android.util.Log;
-import android.view.GestureDetector;
 import android.view.LayoutInflater;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;

--- a/app/src/main/java/com/example/golocal/adapters/GuidesAdapter.java
+++ b/app/src/main/java/com/example/golocal/adapters/GuidesAdapter.java
@@ -3,6 +3,7 @@ package com.example.golocal.adapters;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.transition.Scene;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.LayoutInflater;

--- a/app/src/main/java/com/example/golocal/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/example/golocal/fragments/ProfileFragment.java
@@ -2,6 +2,8 @@ package com.example.golocal.fragments;
 
 import static android.app.Activity.RESULT_OK;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -54,6 +56,7 @@ public class ProfileFragment extends Fragment {
     private static final int CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE = 42;
     private static final int PICK_PHOTO_CODE = 1046;
     private final String photoFileName = "photo.jpg";
+    private int shortAnimationDuration;
 
     private final String KEY_BIO = "bio";
     private static final String KEY_IMAGE = "profileImage";
@@ -126,6 +129,8 @@ public class ProfileFragment extends Fragment {
         ibAddFriend = view.findViewById(R.id.ibAddFriend);
         ibRemoveFriend = view.findViewById(R.id.ibRemoveFriend);
 
+        shortAnimationDuration = getResources().getInteger(android.R.integer.config_shortAnimTime);
+
         List<ParseUser> friends = ParseUser.getCurrentUser().getList(KEY_FRIENDS);
         if (friends != null) {
             for (int i = 0; i < friends.size(); i++) {
@@ -179,15 +184,12 @@ public class ProfileFragment extends Fragment {
             }
         });
 
-
         btEditBio.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                tvBio.setVisibility(View.GONE);
-                etBio.setVisibility(View.VISIBLE);
+                crossfade(tvBio, etBio);
                 etBio.setText(tvBio.getText().toString());
-                btEditBio.setVisibility(View.GONE);
-                btFinishEditBio.setVisibility(View.VISIBLE);
+                crossfade(btEditBio, btFinishEditBio);
                 btFinishEditBio.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -201,14 +203,32 @@ public class ProfileFragment extends Fragment {
                             }
                         });
                         tvBio.setText(user.getString(KEY_BIO));
-                        tvBio.setVisibility(View.VISIBLE);
-                        etBio.setVisibility(View.GONE);
-                        btEditBio.setVisibility(View.VISIBLE);
-                        btFinishEditBio.setVisibility(View.GONE);
+                        crossfade(etBio, tvBio);
+                        crossfade(btFinishEditBio, btEditBio);
                     }
                 });
             }
         });
+    }
+
+    private void crossfade(View startingView, View endingView) {
+        endingView.setAlpha(0f);
+        endingView.setVisibility(View.VISIBLE);
+
+        endingView.animate()
+                .alpha(1f)
+                .setDuration(shortAnimationDuration)
+                .setListener(null);
+
+        startingView.animate()
+                .alpha(0f)
+                .setDuration(shortAnimationDuration)
+                .setListener(new AnimatorListenerAdapter() {
+                    @Override
+                    public void onAnimationEnd(Animator animation) {
+                        startingView.setVisibility(View.GONE);
+                    }
+                });
     }
 
     private void setAddFriendListener() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/scene_root"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"


### PR DESCRIPTION
I added a crossfade animation when the user clicks the button to edit their bio. Specifically, the input box and finish editing bio buttons crossfade in. When the user clicks the button to finish editing their bio, the originally text and edit bio views crossfade back in. I've attached a video below where you can see what this looks like.

https://user-images.githubusercontent.com/26172675/179851151-3cd44cf7-a33f-4e76-9a2f-636bf260af0b.mov


